### PR TITLE
Fixed link to albumentations examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,18 @@ If you wish to cite us, you can cite followings paper of your choice:  [Style tr
 #### - [albumentations](https://github.com/albu/albumentations) ![](https://img.shields.io/github/stars/albu/albumentations.svg?style=social) is a python library with a set of useful, large and diverse data augmentation methods. It offers over 30 different types of augmentations, easy and ready to use. Moreover, as the authors prove, the library is faster than other libraries on most of the transformations. 
 
 Example jupyter notebooks:
-* [All in one showcase notebook](https://github.com/albu/albumentations/blob/master/notebooks/showcase.ipynb)
-* [Classification](https://github.com/albu/albumentations/blob/master/notebooks/example.ipynb),
-* [Object detection](https://github.com/albu/albumentations/blob/master/notebooks/example_bboxes.ipynb),  [image segmentation](https://github.com/albu/albumentations/blob/master/notebooks/example_kaggle_salt.ipynb) and  [keypoints](https://github.com/albu/albumentations/blob/master/notebooks/example_keypoints.ipynb)
-* Others - [Weather transforms ](https://github.com/albu/albumentations/blob/master/notebooks/example_weather_transforms.ipynb),
- [Serialization](https://github.com/albu/albumentations/blob/master/notebooks/serialization.ipynb),
- [Replay/Deterministic mode](https://github.com/albu/albumentations/blob/master/notebooks/replay.ipynb),  [Non-8-bit images](https://github.com/albu/albumentations/blob/master/notebooks/example_16_bit_tiff.ipynb)
+* [All in one showcase notebook](https://github.com/albu/albumentations_examples/blob/master/notebooks/showcase.ipynb)
+* [Classification](https://github.com/albu/albumentations_examples/blob/master/notebooks/example.ipynb),
+* [Object detection](https://github.com/albu/albumentations_examples/blob/master/notebooks/example_bboxes.ipynb),  [image segmentation](https://github.com/albu/albumentations_examples/blob/master/notebooks/example_kaggle_salt.ipynb) and  [keypoints](https://github.com/albu/albumentations_examples/blob/master/notebooks/example_keypoints.ipynb)
+* Others - [Weather transforms ](https://github.com/albu/albumentations_examples/blob/master/notebooks/example_weather_transforms.ipynb),
+ [Serialization](https://github.com/albu/albumentations_examples/blob/master/notebooks/serialization.ipynb),
+ [Replay/Deterministic mode](https://github.com/albu/albumentations_examples/blob/master/notebooks/replay.ipynb),  [Non-8-bit images](https://github.com/albu/albumentations_examples/blob/master/notebooks/example_16_bit_tiff.ipynb)
 
 Example tranformations:
 ![albumentations examples](https://s3.amazonaws.com/assertpub/image/1809.06839v1/image-002-000.png)
 
 #### - [imgaug](https://github.com/aleju/imgaug) ![](https://img.shields.io/github/stars/aleju/imgaug.svg?style=social) - is another very useful and widely used python library. As authors describe: *it helps you with augmenting images for your machine learning projects. It converts a set of input images into a new, much larger set of slightly altered images.* It offers many augmentation techniques such as affine transformations, perspective transformations, contrast changes, gaussian noise, dropout of regions, hue/saturation changes, cropping/padding, blurring.
+
 
 Example jupyter notebooks:
 * [Load and Augment an Image](https://nbviewer.jupyter.org/github/aleju/imgaug-doc/blob/master/notebooks/A01%20-%20Load%20and%20Augment%20an%20Image.ipynb)


### PR DESCRIPTION
albumentations team moved their examples to a different repository:
https://github.com/albumentations-team/albumentations_examples
Updates links in readme file